### PR TITLE
Fix issues when the initial (cached) request is json

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -228,6 +228,7 @@ HttpCache.prototype = {
           }
 
           if (responseEtag && response.statusCode === 200) {
+
             /* Store the cache response async */
             self._storeResponse(requestUrl, options.headers, response, expiry, responseEtag, body, requestStartTime, function(err) {
               if (err) {
@@ -278,6 +279,10 @@ HttpCache.prototype = {
     /* Regenerate the key using the new vary header */
     var key = keyGenerator(requestUrl, requestHeaders, vary);
 
+    if (typeof body === 'object') {
+      body = _.cloneDeep(body);
+    }
+
     this.backend.store(key, {
         url: requestUrl,
         statusCode: response.statusCode,
@@ -303,7 +308,7 @@ HttpCache.prototype = {
       try {
         var parsed;
         if( typeof cachedContent.body === 'object' ) {
-            parsed = cachedContent.body;
+            parsed = _.cloneDeep(cachedContent.body);
         } else {
             parsed = JSON.parse(cachedContent.body);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -301,7 +301,12 @@ HttpCache.prototype = {
     if (options.json) {
       /* Use the cached response */
       try {
-        var parsed = JSON.parse(cachedContent.body);
+        var parsed;
+        if( typeof cachedContent.body === 'object' ) {
+            parsed = cachedContent.body;
+        } else {
+            parsed = JSON.parse(cachedContent.body);
+        }
         return callback(null, response, parsed);
       } catch(e) {
         this.stats.increment('json.parse.error');
@@ -310,7 +315,13 @@ HttpCache.prototype = {
     }
 
     /* Use the cached response */
-    return callback(null, response, cachedContent.body);
+    var stringified;
+    if( typeof cachedContent.body === 'string' ) {
+        stringified = cachedContent.body;
+    } else {
+        stringified = JSON.stringify(cachedContent.body);
+    }
+    return callback(null, response, stringified);
   }
 };
 

--- a/test/request-http-cache-test.js
+++ b/test/request-http-cache-test.js
@@ -261,50 +261,156 @@ describe('request-http-cache', function() {
     describe('it should handle json initial requests', function() {
 
       describe('when subsequent request is json', function() {
-        var httpRequestCache;
-        var err, path, response, body;
 
-        beforeEach(function(done) {
-          var mockBackend = new RequestHttpCache.backends.InMemory();
-          var k = keyGenerator('https://api.github.com' + path, {}, null);
+        describe('when single subsequent request', function() {
+          var httpRequestCache;
+          var err, path, response, body;
 
-          mockBackend.store(k, {
-            url: 'https://api.github.com' + path,
-            statusCode: 200,
-            etag: '1234',
-            expiry: Date.now() + 1000,
-            headers: {
-              'content-type': MIME_JSON
-            },
-            body: { hello: 'cached' } // JSON data
-          }, function() {});
+          beforeEach(function(done) {
+            var mockBackend = new RequestHttpCache.backends.InMemory();
+            var k = keyGenerator('https://api.github.com' + path, {}, null);
 
-          httpRequestCache = new RequestHttpCache({
-            backend: mockBackend
+            mockBackend.store(k, {
+              url: 'https://api.github.com' + path,
+              statusCode: 200,
+              etag: '1234',
+              expiry: Date.now() + 1000,
+              headers: {
+                'content-type': MIME_JSON
+              },
+              body: { hello: 'cached' } // JSON data
+            }, function() {});
+
+            httpRequestCache = new RequestHttpCache({
+              backend: mockBackend
+            });
+
+            httpRequestCache.extension({
+               url: 'https://api.github.com' + path,
+               json: true
+              }, function(_err, _response, _body) {
+              err = _err;
+              response = _response;
+              body = _body;
+              done();
+             }, request);
+
           });
 
-          httpRequestCache.extension({
-             url: 'https://api.github.com' + path,
-             json: true
-            }, function(_err, _response, _body) {
-            err = _err;
-            response = _response;
-            body = _body;
-            done();
-           }, request);
 
+          before(function() {
+            path = '/json1';
+          });
+
+          it('should return cached response', function() {
+            assert(!err);
+            assert.strictEqual(response.statusCode, 200);
+            assert.strictEqual(response.headers['content-type'], MIME_JSON);
+            assert.deepEqual(body, { hello: 'cached' });
+          });
         });
 
+        describe('when multiple subsequent requests', function() {
+          var httpRequestCache;
+          var err, path, response, body;
 
-        before(function() {
-          path = '/hit1';
+          beforeEach(function(done) {
+            var mockBackend = new RequestHttpCache.backends.InMemory();
+            var k = keyGenerator('https://api.github.com' + path, {}, null);
+
+            mockBackend.store(k, {
+              url: 'https://api.github.com' + path,
+              statusCode: 200,
+              etag: '1234',
+              expiry: Date.now() + 1000,
+              headers: {
+                'content-type': MIME_JSON
+              },
+              body: { hello: 'cached' } // JSON data
+            }, function() {});
+
+            httpRequestCache = new RequestHttpCache({
+              backend: mockBackend
+            });
+
+            httpRequestCache.extension({
+               url: 'https://api.github.com' + path,
+               json: true
+              }, function(_err1, _response1, _body1) {
+              _body1.extra = 'extra';
+              httpRequestCache.extension({
+                 url: 'https://api.github.com' + path,
+                 json: true
+                }, function(_err, _response, _body) {
+                err = _err;
+                response = _response;
+                body = _body;
+                done();
+               }, request);
+             }, request);
+
+          });
+
+
+          before(function() {
+            path = '/json1';
+          });
+
+          it('separate requests should not affect each other', function() {
+            assert(!err);
+            assert.strictEqual(response.statusCode, 200);
+            assert.strictEqual(response.headers['content-type'], MIME_JSON);
+            assert.deepEqual(body, { hello: 'cached' });
+          });
         });
 
-        it('should return cached response', function() {
-          assert(!err);
-          assert.strictEqual(response.statusCode, 200);
-          assert.strictEqual(response.headers['content-type'], MIME_JSON);
-          assert.deepEqual(body, { hello: 'cached' });
+        describe.only('when initial request modifies response', function() {
+          var httpRequestCache;
+          var err, path, response, body;
+
+          beforeEach(function(done) {
+            scope.get(path)
+                 .reply(200, JSON.stringify({ hello: 'cached' }), {
+                   etag: '1234',
+                   'cache-control': 'private, max-age=60',
+                   'content-type': MIME_JSON
+                  });
+
+            var mockBackend = new RequestHttpCache.backends.InMemory();
+
+            httpRequestCache = new RequestHttpCache({
+              backend: mockBackend
+            });
+
+            httpRequestCache.extension({
+               url: 'https://api.github.com' + path,
+               json: true
+              }, function(_err1, _response1, _body1) {
+              _body1.extra = 'extra';
+              httpRequestCache.extension({
+                 url: 'https://api.github.com' + path,
+                 json: true
+                }, function(_err, _response, _body) {
+                err = _err;
+                response = _response;
+                body = _body;
+                done();
+               }, request);
+             }, request);
+
+          });
+
+
+          before(function() {
+            path = '/json1';
+          });
+
+          it('subsequent requests should return original response', function() {
+            assert(!err);
+            assert.strictEqual(response.statusCode, 200);
+            assert.strictEqual(response.headers['content-type'], MIME_JSON);
+            assert.deepEqual(body, { hello: 'cached' });
+          });
         });
       });
 
@@ -345,7 +451,7 @@ describe('request-http-cache', function() {
 
 
         before(function() {
-          path = '/hit1';
+          path = '/json2';
         });
 
         it('should return cached response', function() {
@@ -798,7 +904,7 @@ describe('request-http-cache', function() {
           },
           body: "WRONG"
         }, function() {});
-  
+
         return callback(null, {
           url: 'https://api.github.com/xxxx', // <-- NB
           etag: '2345',

--- a/test/request-http-cache-test.js
+++ b/test/request-http-cache-test.js
@@ -260,101 +260,101 @@ describe('request-http-cache', function() {
 
     describe('it should handle json initial requests', function() {
 
-        describe('when subsequent request is json', function() {
-            var httpRequestCache;
-            var err, path, response, body;
+      describe('when subsequent request is json', function() {
+        var httpRequestCache;
+        var err, path, response, body;
 
-            beforeEach(function(done) {
-              var mockBackend = new RequestHttpCache.backends.InMemory();
-              var k = keyGenerator('https://api.github.com' + path, {}, null);
+        beforeEach(function(done) {
+          var mockBackend = new RequestHttpCache.backends.InMemory();
+          var k = keyGenerator('https://api.github.com' + path, {}, null);
 
-              mockBackend.store(k, {
-                url: 'https://api.github.com' + path,
-                statusCode: 200,
-                etag: '1234',
-                expiry: Date.now() + 1000,
-                headers: {
-                  'content-type': MIME_JSON
-                },
-                body: { hello: 'cached' } // JSON data
-              }, function() {});
+          mockBackend.store(k, {
+            url: 'https://api.github.com' + path,
+            statusCode: 200,
+            etag: '1234',
+            expiry: Date.now() + 1000,
+            headers: {
+              'content-type': MIME_JSON
+            },
+            body: { hello: 'cached' } // JSON data
+          }, function() {});
 
-              httpRequestCache = new RequestHttpCache({
-                backend: mockBackend
-              });
+          httpRequestCache = new RequestHttpCache({
+            backend: mockBackend
+          });
 
-              httpRequestCache.extension({
-                 url: 'https://api.github.com' + path,
-                 json: true
-                }, function(_err, _response, _body) {
-                err = _err;
-                response = _response;
-                body = _body;
-                done();
-               }, request);
+          httpRequestCache.extension({
+             url: 'https://api.github.com' + path,
+             json: true
+            }, function(_err, _response, _body) {
+            err = _err;
+            response = _response;
+            body = _body;
+            done();
+           }, request);
 
-            });
-
-
-            before(function() {
-              path = '/hit1';
-            });
-
-            it('should return cached response', function() {
-              assert(!err);
-              assert.strictEqual(response.statusCode, 200);
-              assert.strictEqual(response.headers['content-type'], MIME_JSON);
-              assert.deepEqual(body, { hello: 'cached' });
-            });
         });
 
-        describe('when subsequent request is not json', function() {
-            var httpRequestCache;
-            var err, path, response, body;
 
-            beforeEach(function(done) {
-              var mockBackend = new RequestHttpCache.backends.InMemory();
-              var k = keyGenerator('https://api.github.com' + path, {}, null);
-
-              mockBackend.store(k, {
-                url: 'https://api.github.com' + path,
-                statusCode: 200,
-                etag: '1234',
-                expiry: Date.now() + 1000,
-                headers: {
-                  'content-type': MIME_JSON
-                },
-                body: { hello: 'cached' } // JSON data
-              }, function() {});
-
-              httpRequestCache = new RequestHttpCache({
-                backend: mockBackend
-              });
-
-              httpRequestCache.extension({
-                 url: 'https://api.github.com' + path,
-                 json: false
-                }, function(_err, _response, _body) {
-                err = _err;
-                response = _response;
-                body = _body;
-                done();
-               }, request);
-
-            });
-
-
-            before(function() {
-              path = '/hit1';
-            });
-
-            it('should return cached response', function() {
-              assert(!err);
-              assert.strictEqual(response.statusCode, 200);
-              assert.strictEqual(response.headers['content-type'], MIME_JSON);
-              assert.deepEqual(body, "{\"hello\":\"cached\"}");
-            });
+        before(function() {
+          path = '/hit1';
         });
+
+        it('should return cached response', function() {
+          assert(!err);
+          assert.strictEqual(response.statusCode, 200);
+          assert.strictEqual(response.headers['content-type'], MIME_JSON);
+          assert.deepEqual(body, { hello: 'cached' });
+        });
+      });
+
+      describe('when subsequent request is not json', function() {
+        var httpRequestCache;
+        var err, path, response, body;
+
+        beforeEach(function(done) {
+          var mockBackend = new RequestHttpCache.backends.InMemory();
+          var k = keyGenerator('https://api.github.com' + path, {}, null);
+
+          mockBackend.store(k, {
+            url: 'https://api.github.com' + path,
+            statusCode: 200,
+            etag: '1234',
+            expiry: Date.now() + 1000,
+            headers: {
+              'content-type': MIME_JSON
+            },
+            body: { hello: 'cached' } // JSON data
+          }, function() {});
+
+          httpRequestCache = new RequestHttpCache({
+            backend: mockBackend
+          });
+
+          httpRequestCache.extension({
+             url: 'https://api.github.com' + path,
+             json: false
+            }, function(_err, _response, _body) {
+            err = _err;
+            response = _response;
+            body = _body;
+            done();
+           }, request);
+
+        });
+
+
+        before(function() {
+          path = '/hit1';
+        });
+
+        it('should return cached response', function() {
+          assert(!err);
+          assert.strictEqual(response.statusCode, 200);
+          assert.strictEqual(response.headers['content-type'], MIME_JSON);
+          assert.deepEqual(body, "{\"hello\":\"cached\"}");
+        });
+      });
     });
   });
 


### PR DESCRIPTION
We JSON.parse and JSON.stringify the cached results as necessary.

Fixes #3.
