### PR TITLE
Fix handling of Vary Headers in Redis Backend

### DIFF
--- a/lib/redis-backend.js
+++ b/lib/redis-backend.js
@@ -17,8 +17,8 @@ var JSONBSerializer = require('./jsonb-serializer');
 var NullCompressor = require('./null-compressor');
 
 function bufferToString(buffer) {
-  if (!buffer) return null;
   if (typeof buffer === 'string') return buffer;
+  if (!buffer) return null;
 
   return buffer.toString('utf8');
 }


### PR DESCRIPTION
This should fix the bug documented at https://github.com/gitterHQ/request-http-cache/issues/12 which ensures that all resources without Vary headers cannot be cached at all by the Redis backend.